### PR TITLE
remove obsolete ADDON_* methods (fixes build after xbmc/xbmc#12011)

### DIFF
--- a/src/SACDFile.cpp
+++ b/src/SACDFile.cpp
@@ -227,15 +227,6 @@ void ADDON_Destroy()
   destroy_logging();
 }
 
-//-- HasSettings --------------------------------------------------------------
-// Returns true if this add-on use settings
-// !!! Add-on master function !!!
-//-----------------------------------------------------------------------------
-bool ADDON_HasSettings()
-{
-  return false;
-}
-
 //-- GetStatus ---------------------------------------------------------------
 // Returns the current Status of this visualisation
 // !!! Add-on master function !!!
@@ -245,24 +236,6 @@ ADDON_STATUS ADDON_GetStatus()
   return ADDON_STATUS_OK;
 }
 
-//-- GetSettings --------------------------------------------------------------
-// Return the settings for XBMC to display
-// !!! Add-on master function !!!
-//-----------------------------------------------------------------------------
-unsigned int ADDON_GetSettings(ADDON_StructSetting ***sSet)
-{
-  return 0;
-}
-
-//-- FreeSettings --------------------------------------------------------------
-// Free the settings struct passed from XBMC
-// !!! Add-on master function !!!
-//-----------------------------------------------------------------------------
-
-void ADDON_FreeSettings()
-{
-}
-
 //-- SetSetting ---------------------------------------------------------------
 // Set a specific Setting value (called from XBMC)
 // !!! Add-on master function !!!
@@ -270,14 +243,6 @@ void ADDON_FreeSettings()
 ADDON_STATUS ADDON_SetSetting(const char *strSetting, const void* value)
 {
   return ADDON_STATUS_OK;
-}
-
-//-- Announce -----------------------------------------------------------------
-// Receive announcements from XBMC
-// !!! Add-on master function !!!
-//-----------------------------------------------------------------------------
-void ADDON_Announce(const char *flag, const char *sender, const char *message, const void *data)
-{
 }
 
 struct SACDContext


### PR DESCRIPTION
Build-tested only, since I struggle to get something usable out of the VFS addon (even with https://github.com/xbmc/xbmc/pull/12004 applied my SACD ISOs won't show in music/files).